### PR TITLE
Fix year range interval

### DIFF
--- a/client/templates/blindspot_map.coffee
+++ b/client/templates/blindspot_map.coffee
@@ -10,13 +10,13 @@ Template.blindspotMap.onCreated ->
     .fail (e)->
       console.log e
   @minYear = new ReactiveVar 1994
-  @maxYear = new ReactiveVar 2015
+  @maxYear = new ReactiveVar 2016
   Blindspots.find().observeChanges(
     added: (id, fields)=>
       if fields.year < @minYear.get()
         @minYear.set(fields.year)
-      else if fields.year > @maxYear.get()
-        @maxYear.set(fields.year)
+      else if fields.year + 1 > @maxYear.get()
+        @maxYear.set(fields.year + 1)
   )
 Template.blindspotMap.onRendered ->
   L.Icon.Default.imagePath = 'packages/bevanhunt_leaflet/images'
@@ -136,7 +136,7 @@ Template.blindspotMap.onRendered ->
         }
         {
           year:
-            $lte: @endYear.get()
+            $lt: @endYear.get()
         }
       ]
     ).fetch())


### PR DESCRIPTION
Before, when viewing a year range like "from 2002 to 2003," all the data from 2003 was included, but people will typically interpret this as meaning a one year interval from the beginning to the end of 2002. This update removes last year from year range interval to match those conventions.
