### PR TITLE
Sidebar tab style updates

### DIFF
--- a/client/stylesheets/globals.import.styl
+++ b/client/stylesheets/globals.import.styl
@@ -46,6 +46,13 @@
     .loading-text
       font-size 1.5em
 
+.empty
+  td
+    text-align center
+    font-style italic
+  &::before
+    display none
+
 for $num in -1 0 1 2 3
   .space-btm-{$num}
     margin-bottom $num*10px

--- a/client/templates/spa_table.coffee
+++ b/client/templates/spa_table.coffee
@@ -34,9 +34,17 @@ Template.spaTable.helpers
       else
        return value * instance.sortOrder.get()
     )
-      
+
   ready: ->
     Template.instance().ready.get()
+
+  sortDirectionClass: ->
+    instance = Template.instance()
+    if @name == instance.sortBy.get()
+      if instance.sortOrder.get() == 1
+        'tablesorter-headerAsc'
+      else
+        'tablesorter-headerDesc'
 
 Template.spaTable.events
   'click th': (event, instance) ->

--- a/client/templates/spa_table.jade
+++ b/client/templates/spa_table.jade
@@ -13,7 +13,7 @@ template(name="spaTable")
             thead
               tr.tablesorter-headerRow(role="row")
                 each cells
-                  th.tablesorter-header.tablesorter-headerUnSorted(data-column="0" tabindex="0" scope="col" role="columnheader" aria-disabled="false" aria-controls="exploreTable" unselectable="on" aria-sort="{{name}}" aria-label="Origin: No sort applied, activate to apply an ascending sort" style="-webkit-user-select: none;")
+                  th.tablesorter-header.tablesorter-headerUnSorted(class="{{sortDirectionClass}}" data-column="0" tabindex="0" scope="col" role="columnheader" aria-disabled="false" aria-controls="exploreTable" unselectable="on" aria-sort="{{name}}" aria-label="Origin: No sort applied, activate to apply an ascending sort" style="-webkit-user-select: none;")
                     .tablesorter-header-inner= title
             tbody(aria-live="polite" aria-relevant="all")
               if data
@@ -24,9 +24,9 @@ template(name="spaTable")
                     td= population
                     td= mentionsPerCapita
               else
-                tr.row
-                  td(colspan="12")
-                    span(style="font-style: italic;") No data
+                tr.row.empty
+                  td(colspan="4")
+                    span No data
     else
       .loading.small.space-top-3
         .loading-spinner


### PR DESCRIPTION
- Adds sorting indicators to table headers
- Adds loading spinner to table
- Changes how start and end dates are displayed in table header
- removes `div` from jade template (divs are implied)
